### PR TITLE
ci: group npm deps in dependabot to prevent coupled peer-dep failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,31 @@ updates:
       - dependencies
       - javascript
     open-pull-requests-limit: 5
+    groups:
+      vite-ecosystem:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+          - "@tailwindcss/vite"
+          - "vitest"
+          - "@vitest/*"
+      react-ecosystem:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+          - "react-router"
+      eslint-ecosystem:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+          - "globals"
+      types:
+        patterns:
+          - "@types/*"
+        exclude-patterns:
+          - "@types/react"
+          - "@types/react-dom"


### PR DESCRIPTION
## Summary
- Adds `groups:` to the npm dependabot config so related packages bundle into a single PR with one coherent lockfile
- Prevents the failure mode that hit #117 + #120 today (vite 8 ↔ plugin-react 6 each opened as its own PR; neither could pass `npm ci` alone)
- Groups: `vite-ecosystem`, `react-ecosystem`, `eslint-ecosystem`, generic `types` (with React types excluded so they stay with the react group)

## Why these specific groups
Each group covers packages that share a release cadence and peer-dep constraints. Group order matters — dependabot assigns each dep to the *first* matching group, so listing `react-ecosystem` before `types` keeps `@types/react` bundled with React. The `exclude-patterns` on `types` is a defensive double-guard against future reorderings.

## What this does not change
- Go modules, GitHub Actions, and Docker dependabot blocks are unchanged
- Existing open PRs (#117, #120) are unaffected; grouping applies to dependabot's next run

## Test plan
- [ ] Merge and observe next Monday's dependabot run produces grouped PRs rather than individual per-package PRs
- [ ] Verify a grouped PR's lockfile resolves cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)