### PR TITLE
ci: group coupled dependabot updates (codeql-action, typescript)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,20 @@ updates:
       - dependencies
       - ci
     open-pull-requests-limit: 5
+    groups:
+      # github/codeql-action/* sub-actions MUST bump together. init writes a
+      # config file that analyze reads, and the two refuse to talk across a
+      # version boundary ("Loaded a configuration file for version X, but
+      # running version Y"). Bumping them in separate PRs leaves main red from
+      # the moment the first merges until the second does.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+      actions-all:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: docker
     directory: /docker
@@ -62,11 +76,15 @@ updates:
           - "@types/react"
           - "@types/react-dom"
           - "react-router"
+      # typescript belongs here rather than in a group of its own: typescript-eslint
+      # declares a peer range on typescript, so bumping either alone gives npm an
+      # unsatisfiable tree (ERESOLVE) and the PR can never go green. They move together.
       eslint-ecosystem:
         patterns:
           - "eslint"
           - "eslint-*"
           - "@eslint/*"
+          - "typescript"
           - "typescript-eslint"
           - "globals"
       types:


### PR DESCRIPTION
## What

Groups two pairs of dependencies that Dependabot has been updating independently, even though each pair only works when both halves move together.

- **`github/codeql-action/*`** (`init`, `analyze`, and any future sub-action) -> one `codeql-action` group.
- **`typescript` + `typescript-eslint`** -> both now in `eslint-ecosystem`.

## Why

**CodeQL.** `init` writes a config file stamped with its own version, and `analyze` refuses to read a config whose version it does not match. Dependabot treats the two sub-actions as separate dependencies, so it opens a separate PR for each. The moment the first one merges, `main` is skewed and every open PR fails.

That is not hypothetical, it is what happened here:

| commit | effect |
|---|---|
| #129 | both at 4.36.2, aligned |
| #147 | analyze -> 4.36.3, init still 4.36.2 |
| #145 | init -> 4.37.0, analyze still 4.36.3 -- **CI red** |
| #155 | analyze -> 4.37.0, aligned again by luck |

Every open PR failed with `Loaded a configuration file for version '4.37.0', but running version '4.36.3'` for that entire window. It resolved only because the second bump happened to land. Without grouping, this recurs on **every** CodeQL release.

**TypeScript.** `typescript-eslint` declares a peer range on `typescript`. Bumping `typescript` on its own produces an unsatisfiable npm tree, so the PR can never go green no matter how many times it is rebased. The open TypeScript 7 bump (#160) is stuck on precisely this. Grouping lets the major land as one resolvable set.

The general shape: Dependabot's unit of update is the *package*, but the unit of correctness is the *compatible set*. Grouping is how you tell it the difference.

## Verification

- `dependabot.yml` parses; all four npm groups and both new github-actions groups resolve.
- CodeQL on `main` confirmed green after the accidental realignment, so the current state is a valid baseline.
- Config-only change; no application code touched.

## Notes

`actions-all` carries an `exclude-patterns` for `github/codeql-action*` so the codeql group owns those exclusively and they cannot leak back into the catch-all.