### PR TITLE
ci: stop dependabot proposing an unlandable TypeScript 7 bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,3 +93,11 @@ updates:
         exclude-patterns:
           - "@types/react"
           - "@types/react-dom"
+    ignore:
+      # typescript-eslint peers typescript ">=4.8.4 <6.1.0" at every published
+      # version, alphas included, so TypeScript 7 cannot resolve alongside it.
+      # Dependabot re-proposes the bump weekly and it can never go green. Drop
+      # this ignore once typescript-eslint ships TS 7 support.
+      - dependency-name: "typescript"
+        versions: [">=6.1.0"]
+


### PR DESCRIPTION
## What

Tells Dependabot to stop proposing TypeScript 7, which cannot be adopted here yet.

## Why

`typescript-eslint` declares this peer range at **every published version, prereleases included**:

```
peer typescript: ">=4.8.4 <6.1.0"
```

There is no release of `typescript-eslint` that can resolve alongside TypeScript 7. The bump dies in `npm ci` with `ERESOLVE` and **cannot go green** by any means available to us:

- Rebasing does not help: the conflict is structural, not a stale base.
- Grouping `typescript` with `typescript-eslint` so they move in lockstep does not help either. That was the previous fix, and it worked exactly as intended -- Dependabot re-opened the bump as a grouped PR that moved `typescript-eslint` to its latest 8.64.0 **and it still failed**, because 8.64.0 peers below TS 7 just like every version before it.

The blocker is upstream and outside our control. Until `typescript-eslint` ships TS 7 support, every weekly Dependabot run re-proposes a PR that is dead on arrival and burns a CI cycle proving it again.

This ignores `typescript >= 6.1.0` (the ceiling of that peer range). **Drop the ignore once upstream catches up** -- the comment in the config says so, so this does not silently ossify into a permanent pin.

## Verification

Queried the registry rather than inferring:

| package | peer `typescript` |
|---|---|
| `typescript-eslint@8.64.0` (latest) | `>=4.8.4 <6.1.0` |
| `@typescript-eslint/eslint-plugin@8.64.0` | `>=4.8.4 <6.1.0` |
| `8.64.1-alpha.0`, `8.63.1-alpha.*` | `>=4.8.4 <6.1.0` |

Config-only change; no application code touched.